### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -125,19 +125,19 @@ jobs:
         ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.6
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.6
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.6
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.6
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.6
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.6
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.CLITool
+      python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
   #UnitTesting:
   #  uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0
@@ -124,8 +125,19 @@ jobs:
         ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.6
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.7
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.8
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.9
-#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.10
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.6
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.6
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.6
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
+#        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10


### PR DESCRIPTION
# Changes

* ci/Params: override python_version_list, since 3.6 was deprecated in pyTooling/Actions.