### PR TITLE
v0.3.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
       - Dependencies
     reviewers:
       - Paebbels
-      - Umarcor
     schedule:
       interval: "daily"    # Checks on Monday trough Friday.
 
@@ -24,6 +23,5 @@ updates:
       - Dependencies
     reviewers:
       - Paebbels
-      - Umarcor
     schedule:
       interval: "weekly"

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -240,7 +240,6 @@ jobs:
     with:
       version:  ${{ needs.Prepare.outputs.version }}
       auto_tag: ${{ needs.Prepare.outputs.is_release_commit }}
-    secrets: inherit
 
   ReleasePage:
     uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@dev
@@ -253,7 +252,6 @@ jobs:
       - PublishToGitHubPages
     with:
       tag: ${{ needs.Prepare.outputs.version }}
-    secrets: inherit
 
   PublishOnPyPI:
     uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r4
@@ -265,7 +263,8 @@ jobs:
       python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
       requirements:   '-r dist/requirements.txt'
       artifact:       ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
-    secrets: inherit
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   ArtifactCleanUp:
     uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r4

--- a/pyEDAA/CLITool/__init__.py
+++ b/pyEDAA/CLITool/__init__.py
@@ -34,7 +34,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2014-2025, Patrick Lehmann, Unai Martinez-Corral"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.3.5"
+__version__ =   "0.3.6"
 __keywords__ =  ["cli", "abstraction layer", "eda"]
 
 from pathlib import Path

--- a/run.ps1
+++ b/run.ps1
@@ -33,7 +33,7 @@ Param(
 )
 
 $PackageName = "pyEDAA.CLITool"
-$PackageVersion = "0.3.5"
+$PackageVersion = "0.3.6"
 
 # set default values
 $EnableDebug =        [bool]$PSCmdlet.MyInvocation.BoundParameters["Debug"]


### PR DESCRIPTION
# Unit Tests

* Use explicit secret for PyPI so publishing to PyPI works again.  
  (🪳 in GitHub Actions `secrets: inherit` syntax)
